### PR TITLE
make explicit selection of numSources dimension

### DIFF
--- a/contrib/nutmegtrip/nmt_polaritytweak.m
+++ b/contrib/nutmegtrip/nmt_polaritytweak.m
@@ -47,7 +47,7 @@ end
 % end
 
 
-for ii=1:length(s)
+for ii=1:size(s,1)
     source.avg.mom{inside_idx(ii)} = s(ii,:);
     source.avg.ori{inside_idx(ii)} = ori(:,ii);
 end


### PR DESCRIPTION
if numSources < numTimepoints, length() will select the larger (wrong) dimension. 
s = [numSources, numTimepoints]